### PR TITLE
RangeError fix

### DIFF
--- a/s3-slider.js
+++ b/s3-slider.js
@@ -83,7 +83,7 @@ $.fn.s3Slider = function(vars) {
 
   //GO!
   $('span',items[0]).css('opacity',spanOpacity); //set initial opacity
-  setSlideTimeout(visible(items[0]) ? timeout : 0); //start sliding
+  setSlideTimeout(visible($(items[0])) ? timeout : 0); //start sliding
 };
 
 

--- a/s3-slider.js
+++ b/s3-slider.js
@@ -34,7 +34,7 @@ $.fn.s3Slider = function(vars) {
   });
 
   function visible(item){
-    return $(item).css('display')!='none'
+    return item.css('display')!='none'
   }
 
   function slide(){


### PR DESCRIPTION
The function visible(item) is wrapping the item parameter onto a jQuery object, but the item parameter is already a jQuery object thus generating an Uncaught RangeError (Maximum call stack size exceeded)